### PR TITLE
fix: translate parse

### DIFF
--- a/src/utils/translate.ts
+++ b/src/utils/translate.ts
@@ -20,7 +20,8 @@ export const translateText = {
       return [ undefined, undefined ]
     }
 
-    const translateBody: string[] = text.split(MAGIC_JOIN_STRING)
+    // fix translate "@@====" to "@@== =="
+    const translateBody: string[] = text.split(/@@==\s?==/)
     return [ translateBody?.[0]?.trim(), translateBody[1].trim() ]
   },
   stringify(body?: string, title?: string) {


### PR DESCRIPTION
Sometimes, the google translator will translate “@@====” to “@@== ==", which cause NPE problem.

You can see this failed action: https://github.com/monkeyWie/proxyee/actions/runs/5585689405/jobs/10208747504